### PR TITLE
add atomic and timeout options

### DIFF
--- a/live/apps/api/terraform.tfvars.json
+++ b/live/apps/api/terraform.tfvars.json
@@ -6,5 +6,7 @@
     "okta_org_name": "",
     "okta_base_url": "",
     "aws_resource_name_prefix": "#{AWS_IAM_PREFIX}",
-    "namespace": "#{Octopus.ProjectGroup.Name}"
+    "namespace": "#{Octopus.ProjectGroup.Name}",
+    "atomic": "#{HELM_ATOMIC}",
+    "timeout": "#{HELM_TIMEOUT}"
 }

--- a/live/apps/cron/terraform.tfvars.json
+++ b/live/apps/cron/terraform.tfvars.json
@@ -3,5 +3,7 @@
     "namespace": "#{Octopus.ProjectGroup.Name}",
     "cluster_name": "#{CLUSTER_NAME}",
     "revision": "#{Octopus.Release.Number}",
-    "aws_resource_name_prefix": "#{AWS_IAM_PREFIX}"
+    "aws_resource_name_prefix": "#{AWS_IAM_PREFIX}",
+    "atomic": "#{HELM_ATOMIC}",
+    "timeout": "#{HELM_TIMEOUT}"
 }

--- a/live/apps/handler/terraform.tfvars.json
+++ b/live/apps/handler/terraform.tfvars.json
@@ -3,5 +3,7 @@
     "namespace": "#{Octopus.ProjectGroup.Name}",
     "cluster_name": "#{CLUSTER_NAME}",
     "revision": "#{Octopus.Release.Number}",
-    "aws_resource_name_prefix": "#{AWS_IAM_PREFIX}"
+    "aws_resource_name_prefix": "#{AWS_IAM_PREFIX}",
+    "atomic": "#{HELM_ATOMIC}",
+    "timeout": "#{HELM_TIMEOUT}"
 }

--- a/live/apps/ui/terraform.tfvars.json
+++ b/live/apps/ui/terraform.tfvars.json
@@ -4,5 +4,7 @@
     "revision": "#{Octopus.Release.Number}",
     "domain": "#{DOMAIN}",
     "aws_resource_name_prefix": "#{AWS_IAM_PREFIX}",
-    "namespace": "#{Octopus.ProjectGroup.Name}"
+    "namespace": "#{Octopus.ProjectGroup.Name}",
+    "atomic": "#{HELM_ATOMIC}",
+    "timeout": "#{HELM_TIMEOUT}"
 }

--- a/modules/apps/api/README.md
+++ b/modules/apps/api/README.md
@@ -20,6 +20,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_atomic"></a> [atomic](#input\_atomic) | If true, sets atomic flag on helm upgrade, if upgrade fails it reverts it | `bool` | `true` | no |
 | <a name="input_authentication_enabled"></a> [authentication\_enabled](#input\_authentication\_enabled) | Boolean value for Authentication | `bool` | `false` | no |
 | <a name="input_chart_values"></a> [chart\_values](#input\_chart\_values) | Chart values | `list(string)` | n/a | yes |
 | <a name="input_create"></a> [create](#input\_create) | Boolean Value for Create | `bool` | `false` | no |
@@ -32,4 +33,5 @@
 | <a name="input_revision"></a> [revision](#input\_revision) | Octopus Release Number | `string` | n/a | yes |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | Role ARN from apps.hcl | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags Output from Tags Module | `map(string)` | n/a | yes |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout for helm upgrade to finish, in seconds, if not set defaults to 600 | `number` | `600` | no |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/apps/api/main.tf
+++ b/modules/apps/api/main.tf
@@ -42,6 +42,8 @@ resource "helm_release" "api" {
   namespace         = local.namespace
   lint              = true
   dependency_update = true
+  atomic            = var.atomic
+  timeout           = var.timeout
 
   values = local.final_values
 

--- a/modules/apps/api/variables.tf
+++ b/modules/apps/api/variables.tf
@@ -59,3 +59,15 @@ variable "tags" {
   type        = map(string)
   description = "Tags Output from Tags Module"
 }
+
+variable "atomic" {
+  type        = bool
+  description = "If true, sets atomic flag on helm upgrade, if upgrade fails it reverts it"
+  default     = true
+}
+
+variable "timeout" {
+  type        = number
+  description = "Timeout for helm upgrade to finish, in seconds, if not set defaults to 600"
+  default     = 600
+}

--- a/modules/apps/cron/README.md
+++ b/modules/apps/cron/README.md
@@ -20,6 +20,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_atomic"></a> [atomic](#input\_atomic) | If true, sets atomic flag on helm upgrade, if upgrade fails it reverts it | `bool` | `true` | no |
 | <a name="input_chart_values"></a> [chart\_values](#input\_chart\_values) | Chart values | `list(string)` | n/a | yes |
 | <a name="input_create"></a> [create](#input\_create) | Boolean Value for Create | `bool` | `false` | no |
 | <a name="input_image"></a> [image](#input\_image) | Deploy YAML git Image | `string` | n/a | yes |
@@ -28,4 +29,5 @@
 | <a name="input_revision"></a> [revision](#input\_revision) | Octopus Release Number | `string` | n/a | yes |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | Role ARN from apps.hcl | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags Output from Tags Module | `map(string)` | n/a | yes |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout for helm upgrade to finish, in seconds, if not set defaults to 600 | `number` | `600` | no |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/apps/cron/main.tf
+++ b/modules/apps/cron/main.tf
@@ -46,6 +46,8 @@ resource "helm_release" "cron" {
   namespace         = local.namespace
   lint              = true
   dependency_update = true
+  atomic            = var.atomic
+  timeout           = var.timeout
 
   values = local.final_values
 

--- a/modules/apps/cron/variables.tf
+++ b/modules/apps/cron/variables.tf
@@ -38,3 +38,15 @@ variable "tags" {
   type        = map(string)
   description = "Tags Output from Tags Module"
 }
+
+variable "atomic" {
+  type        = bool
+  description = "If true, sets atomic flag on helm upgrade, if upgrade fails it reverts it"
+  default     = true
+}
+
+variable "timeout" {
+  type        = number
+  description = "Timeout for helm upgrade to finish, in seconds, if not set defaults to 600"
+  default     = 600
+}

--- a/modules/apps/handler/README.md
+++ b/modules/apps/handler/README.md
@@ -20,6 +20,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_atomic"></a> [atomic](#input\_atomic) | If true, sets atomic flag on helm upgrade, if upgrade fails it reverts it | `bool` | `true` | no |
 | <a name="input_chart_values"></a> [chart\_values](#input\_chart\_values) | Chart values | `list(string)` | n/a | yes |
 | <a name="input_create"></a> [create](#input\_create) | Boolean Value for Create | `bool` | `false` | no |
 | <a name="input_image"></a> [image](#input\_image) | Deploy YAML git Image | `string` | n/a | yes |
@@ -28,4 +29,5 @@
 | <a name="input_revision"></a> [revision](#input\_revision) | Octopus Release Number | `string` | n/a | yes |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | Role ARN from apps.hcl | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags Output from Tags Module | `map(string)` | n/a | yes |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout for helm upgrade to finish, in seconds, if not set defaults to 600 | `number` | `600` | no |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/apps/handler/main.tf
+++ b/modules/apps/handler/main.tf
@@ -46,6 +46,8 @@ resource "helm_release" "handler" {
   namespace         = local.namespace
   lint              = true
   dependency_update = true
+  atomic            = var.atomic
+  timeout           = var.timeout
 
   values = local.final_values
 

--- a/modules/apps/handler/variables.tf
+++ b/modules/apps/handler/variables.tf
@@ -38,3 +38,15 @@ variable "tags" {
   type        = map(string)
   description = "Tags Output from Tags Module"
 }
+
+variable "atomic" {
+  type        = bool
+  description = "If true, sets atomic flag on helm upgrade, if upgrade fails it reverts it"
+  default     = true
+}
+
+variable "timeout" {
+  type        = number
+  description = "Timeout for helm upgrade to finish, in seconds, if not set defaults to 600"
+  default     = 600
+}

--- a/modules/apps/ui/README.md
+++ b/modules/apps/ui/README.md
@@ -20,6 +20,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_atomic"></a> [atomic](#input\_atomic) | If true, sets atomic flag on helm upgrade, if upgrade fails it reverts it | `bool` | `true` | no |
 | <a name="input_chart_values"></a> [chart\_values](#input\_chart\_values) | Chart values | `list(string)` | n/a | yes |
 | <a name="input_create"></a> [create](#input\_create) | Boolean Value for Create | `bool` | `false` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain | `string` | n/a | yes |
@@ -29,4 +30,5 @@
 | <a name="input_revision"></a> [revision](#input\_revision) | Octopus Release Number | `string` | n/a | yes |
 | <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | Role ARN from apps.hcl | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags Output from Tags Module | `map(string)` | n/a | yes |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout for helm upgrade to finish, in seconds, if not set defaults to 600 | `number` | `600` | no |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/apps/ui/main.tf
+++ b/modules/apps/ui/main.tf
@@ -41,6 +41,8 @@ resource "helm_release" "ui" {
   namespace         = local.namespace
   lint              = true
   dependency_update = true
+  atomic            = var.atomic
+  timeout           = var.timeout
 
   values = local.final_values
 

--- a/modules/apps/ui/variables.tf
+++ b/modules/apps/ui/variables.tf
@@ -43,3 +43,15 @@ variable "tags" {
   type        = map(string)
   description = "Tags Output from Tags Module"
 }
+
+variable "atomic" {
+  type        = bool
+  description = "If true, sets atomic flag on helm upgrade, if upgrade fails it reverts it"
+  default     = true
+}
+
+variable "timeout" {
+  type        = number
+  description = "Timeout for helm upgrade to finish, in seconds, if not set defaults to 600"
+  default     = 600
+}


### PR DESCRIPTION
# Description

Adds atomic flag and timeout parameter for helm_release resource.
Both are defined in HELM variable set and can be overriden by specifying them in project variables in octopus.
`HELM_ATOMIC` - true or false value for atomic upgrade
`HELM_TIMEOUT` - number of seconds before timeout, default 300 (5min), added this because when we set atomic to true it sets wait to true and in case any upgrade takes too long it can easily be updated.

[1775](https://drivevariant.atlassian.net/browse/CLOUD-1775)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Prerequisites:
- update tgva [ref in actions-octopus](https://github.com/variant-inc/actions-octopus/blob/f/cloud-1755-atomic/action.yml#L10) 
- update actions-octopus [ref in project](https://github.com/variant-inc/demo-python-flask-variant-api/blob/demo/luka-2/.github/workflows/octo-push.yaml#L36)

1. test case
- crash container so helm upgrade fails, [commit](https://github.com/variant-inc/demo-python-flask-variant-api/blob/demo/luka-2/Dockerfile#L18)
- [GH actions](https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2655763042)
- [Octopus](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-api-luka/deployments/releases/0.1.0-demo-luka-2-0001.299/deployments/Deployments-41578?activeTab=taskLog)

Results:
```
Error: release demo-api-luka failed, and has been rolled back due to atomic being set: timed out waiting for the condition
```
Helm history:
```
PS C:\Users\luka.baruskin> helm history demo-api-luka -n demo
REVISION        UPDATED                         STATUS          CHART                   APP VERSION     DESCRIPTION
1               Fri Jul  8 13:30:29 2022        superseded      variant-api-2.1.12                      Install complete
2               Mon Jul 11 08:07:11 2022        superseded      variant-api-2.1.12                      Upgrade complete
3               Mon Jul 11 08:17:40 2022        superseded      variant-api-2.1.12                      Upgrade complete
4               Mon Jul 11 12:58:32 2022        superseded      variant-api-2.1.12                      Upgrade complete
5               Tue Jul 12 09:39:35 2022        superseded      variant-api-2.1.12                      Upgrade complete
6               Tue Jul 12 09:49:24 2022        superseded      variant-api-2.1.12                      Upgrade complete
7               Tue Jul 12 09:54:49 2022        superseded      variant-api-2.1.12                      Upgrade complete
8               Tue Jul 12 10:33:26 2022        failed          variant-api-2.1.12                      Upgrade "demo-api-luka" failed: timed out waiting for the condition
9               Tue Jul 12 10:38:28 2022        deployed        variant-api-2.1.12                      Rollback to 7
```
 
[x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
