### PR TITLE
[CLOUD-1743] added actions_octopus_version replicator

### DIFF
--- a/modules/common/replicator/README.md
+++ b/modules/common/replicator/README.md
@@ -18,6 +18,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_actions_octopus_version"></a> [actions\_octopus\_version](#input\_actions\_octopus\_version) | Actions Octopus version | `string` | `"v3"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of the app | `string` | n/a | yes |
 | <a name="input_release_data"></a> [release\_data](#input\_release\_data) | Map of release data | <pre>object({<br>    space             = string<br>    project           = string<br>    repository        = string<br>    user              = string<br>    version           = string<br>    image             = string<br>    is_infrastructure = bool<br>  })</pre> | n/a | yes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/common/replicator/main.tf
+++ b/modules/common/replicator/main.tf
@@ -32,5 +32,6 @@ resource "kubernetes_config_map" "iaac_replicator" {
     "Version" : "${var.release_data.version}"
     "Image" : "${var.release_data.image}"
     "IsInfrastructure" : "${var.release_data.is_infrastructure}"
+    "Actions_Octopus_Version" : "${var.actions_octopus_version}"
   }
 }

--- a/modules/common/replicator/main.tf
+++ b/modules/common/replicator/main.tf
@@ -32,6 +32,6 @@ resource "kubernetes_config_map" "iaac_replicator" {
     "Version" : "${var.release_data.version}"
     "Image" : "${var.release_data.image}"
     "IsInfrastructure" : "${var.release_data.is_infrastructure}"
-    "Actions_Octopus_Version" : "${var.actions_octopus_version}"
+    "ActionsOctopusVersion" : "${var.actions_octopus_version}"
   }
 }

--- a/modules/common/replicator/variables.tf
+++ b/modules/common/replicator/variables.tf
@@ -11,6 +11,12 @@ variable "release_data" {
   description = "Map of release data"
 }
 
+variable "actions_octopus_version" {
+  type        = string
+  default     = "v3"
+  description = "Actions Octopus version"
+}
+
 variable "namespace" {
   type        = string
   description = "Namespace of the app"


### PR DESCRIPTION
# Description

Added `v3` field to each release data item.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Deploy an application to dpl with the actions-octopus defined as
```      
- name: Lazy Action Octopus
        uses: variant-inc/actions-octopus@v3
        with:
          deploy_package_version: 1.0.1-f-cloud-1743-0001.473
```
The `v3` wil be an attribute in `replicator_test_octo_projects` dynamo db for the project.

![image](https://user-images.githubusercontent.com/19310023/179971635-e596c356-f282-4cd6-aa52-76c2a7951dd9.png)



- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
