### PR TITLE
[HOTFIX] block policy edit

### DIFF
--- a/modules/common/role/main.tf
+++ b/modules/common/role/main.tf
@@ -2,6 +2,7 @@ locals {
   namespace   = data.kubernetes_namespace.namespace.metadata[0].name
   oidc_issuer = replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")
 
+  boundary_name     = "${var.aws_resource_name_prefix}${var.name}-boundaryPolicy"
   infra_policy_json = [for k, v in var.policies : v.json]
 }
 
@@ -124,7 +125,7 @@ data "aws_iam_policy_document" "boundary_source" {
       "iam:SetDefaultPolicyVersion"
     ]
     resources = [
-      "arn:aws:iam::*:policy/TestPolicyBoundary"
+      "arn:aws:iam::*:policy/${local.boundary_name}"
     ]
   }
   statement {
@@ -147,7 +148,7 @@ data "aws_iam_policy_document" "boundary_policy" {
 }
 
 resource "aws_iam_policy" "boundary_policy" {
-  name        = "${var.aws_resource_name_prefix}${var.name}-boundaryPolicy"
+  name        = local.boundary_name
   description = "Boundary policy used for roles created by DX"
 
   policy = data.aws_iam_policy_document.boundary_policy.json


### PR DESCRIPTION
# Description

Fixing wrong resource in boundary policy.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Use TVA version `1.0.1-h-cloud-1778-pol0001.472` [git](https://github.com/variant-inc/demo-python-flask-variant-api/blob/demo/luka-2/.github/workflows/octo-push.yaml#L52-L55)
- [Octopus deployment](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2/projects/demo-api-luka/deployments/releases/0.1.0-demo-luka-2-0001.365/deployments/Deployments-42207?activeTab=taskSummary)
- Check [the policy](https://us-east-1.console.aws.amazon.com/iam/home#/policies/arn:aws:iam::786352483360:policy/dpl-demo-api-luka-boundaryPolicy$jsonEditor) in DPL
Resource in Sid `NoBoundaryPolicyEdit` should match policy ARN with * instead of account number.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
